### PR TITLE
Fix readme typo for pointer flag definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ DefineTypeFlag(name string, defaultValue typedValue, usage string)
 *Pointer Definitions are in the format of:*
 ```go
 var ptr TYPE
-DefineTypeFlag(ptr, name string, defaultValue typedValue, usage string)
+DefineTypeFlagVar(ptr, name string, defaultValue typedValue, usage string)
 ```
 
 #### Supported Value Types


### PR DESCRIPTION
At first glance it looked like `DefineTypeFlag()` was the only method available when defining flags. :wink: 