### PR TITLE
FIX documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ DefineTypeFlagVar(ptr, name string, defaultValue typedValue, usage string)
 aliases are always defined as a `rune` to limit them to one character.
 
 ```go
-FlagAlias(alias rune, flagName string)
+AliasFlag(alias rune, flagName string)
 ```
 
 #### Example
@@ -114,7 +114,7 @@ var app = cli.New("0.0.1", "my cli", func(c cli.Command){
 
 func init(){
 	app.DefineBoolFlag("gopher", false, "is it gophertastic?")
-	app.FlagAlias('g', "gopher")
+	app.AliasFlag('g', "gopher")
 }
 
 func main(){


### PR DESCRIPTION
Readme is mentionning `FlagAlias`, but the real method is [AliasFlag](https://github.com/jwaldrip/odin/blob/3c9b06835acdc109f09b24af7f75cb08e825d955/cli/flag_definitions.go#L11).